### PR TITLE
fix: use has_next at log api res

### DIFF
--- a/components/organisms/settings/SecurityLog.vue
+++ b/components/organisms/settings/SecurityLog.vue
@@ -64,12 +64,12 @@ export default Vue.extend({
     fetch() {
       const offset = (this.logPaging.page - 1) * this.logPaging.PER_PAGE
       new AuthApi(this.$store.getters['auth/config'])
-        .getAuthLog(undefined, offset, this.logPaging.PER_PAGE + 1)
+        .getAuthLog(undefined, offset, this.logPaging.PER_PAGE)
         .then(res => {
-          if (res.data.logs.length > this.logPaging.PER_PAGE) {
-            this.logPaging.total = res.data.logs.length + offset
+          if (res.data.has_next) {
+            this.logPaging.total = offset + this.logPaging.PER_PAGE * 2
           }
-          this.logPaging.data = res.data.logs.slice(0, this.logPaging.PER_PAGE)
+          this.logPaging.data = res.data.logs
         })
         .catch(err => {
           this.checkAuthWithStatus(this, err.response.status)

--- a/scripts/api/api.ts
+++ b/scripts/api/api.ts
@@ -87,6 +87,12 @@ export interface AuthLogPassChangeModel {
      * @memberof AuthLogPassChangeModel
      */
     sessionid?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AuthLogPassChangeModel
+     */
+    ipaddr?: string;
 }
 /**
  * 
@@ -131,6 +137,12 @@ export interface AuthLogResModel {
      * @memberof AuthLogResModel
      */
     logs: Array<AuthLogModel>;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AuthLogResModel
+     */
+    has_next: boolean;
 }
 /**
  * Request model for /auth/login


### PR DESCRIPTION
## Checklist

- [x] Has your code worked appropriately?
- [ ] Have you written test code?
- [ ] Has your code passed the test?

## Description

get rid of logic to get whether the next page exists from the front, instead of using has_next at the log API response