### PR TITLE
fix: disable error alert when failed to get own permission

### DIFF
--- a/components/molecules/settings/TeamEdit.vue
+++ b/components/molecules/settings/TeamEdit.vue
@@ -202,23 +202,13 @@ export default Vue.extend({
           const total = res.data.total ?? 0
           const members = res.data.members ?? []
           if (total < 1 || members.length < 1) {
-            failureToast(
-              // @ts-ignore
-              this.$buefy,
-              getToastDesc(TOAST_TYPE.GET_PERMISSION).failure,
-              400
-            )
+            this.ownPermission = 0
+            return
           }
           this.ownPermission = members[0].permission ?? 0
         })
         .catch(err => {
           checkAuthWithStatus(this, err.response.status)
-          failureToast(
-            // @ts-ignore
-            this.$buefy,
-            getToastDesc(TOAST_TYPE.GET_PERMISSION).failure,
-            err.response.status
-          )
         })
     },
     getMembers() {

--- a/scripts/model/toast/index.ts
+++ b/scripts/model/toast/index.ts
@@ -10,7 +10,6 @@ const TOAST_TYPE = {
   SEARCH: 'search',
   ADD_NEW_MEMBER: 'add_new_member',
   REMOVE_MEMBER: 'remove_member',
-  GET_PERMISSION: 'get_permission',
   CHANGE_PERMISSION: 'change_permission',
   GET_MEMBER: 'get_member',
   DELETE_TEAM: 'delete_team',
@@ -85,10 +84,6 @@ const toastDescriptions: { [key: string]: descModel } = {
   get_member: {
     success: '',
     failure: 'Failed to get member',
-  } as descModel,
-  get_permission: {
-    success: '',
-    failure: 'Failed to get permission',
   } as descModel,
   change_permission: {
     success: 'Permission changed',


### PR DESCRIPTION
## Related Issue

close #195 

## Checklist

- [x] Has your code worked appropriately?
- [ ] Have you written test code?
- [ ] Has your code passed in the test?

## Description

- API response will be modified, 404 code to 200 code with an empty array.
- remove failure toast