### PR TITLE
fix: lock icon is overlapped

### DIFF
--- a/components/atoms/cell/UserSearchWideCell.vue
+++ b/components/atoms/cell/UserSearchWideCell.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="user-search-wide-cell-container">
     <div class="icon-box">
-      <fa-icon v-if="isLock" class="lock-icon" icon="lock" />
       <fa-icon v-if="!hasImage" :icon="isTeam ? 'users' : 'user'" />
       <b-image v-if="hasImage" :src="imageUri" />
+      <fa-icon v-if="isLock" class="lock-icon" icon="lock" />
     </div>
     <div class="name">
       {{ name }}

--- a/components/molecules/settings/cell/TeamMemberWideCell.vue
+++ b/components/molecules/settings/cell/TeamMemberWideCell.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="user-wide-cell-container">
     <div class="icon-box">
-      <fa-icon v-if="isLocked" class="lock-icon" icon="lock" />
       <fa-icon v-if="!hasImage" icon="user" />
       <b-image v-if="hasImage" :src="user.member.icon_uri" :rounded="rounded" />
+      <fa-icon v-if="isLocked" class="lock-icon" icon="lock" />
     </div>
     <div class="title-item" v-text="user.member.name" />
     <div class="detail-item" v-text="user.member.uuid" />


### PR DESCRIPTION
## Related Issue

when a user has locked, the user icon overlap on the lock icon

## Checklist

- [x] Has your code worked appropriately?
- [ ] Have you written test code?
- [ ] Has your code passed in the test?

## Description

changed the order of the HTML tag

## Screenshots (if appropriate):

<img width="166" alt="Screen Shot 2021-06-12 at 23 44 23" src="https://user-images.githubusercontent.com/34296711/121779728-22135980-cbd8-11eb-8fa2-e7bcac2a6eb7.png">
