### PR TITLE
Use cache when front build

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,6 +59,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: use cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          node-
     - name: install dependencies
       run: npm ci
     - name: prepare config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: use cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          node-
     - name: install dependencies
       run: npm ci
     - name: prepare config
@@ -85,6 +92,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: use cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          node-
     - name: install dependencies
       run: npm ci
     - name: prepare config


### PR DESCRIPTION
## Related Issue

close #229

## Checklist

- [ ] Has your code worked appropriately?
- [ ] Have you written test code?
- [ ] Has your code passed in the test?

## Description

When building by CI, caching node packages by using actions/cache

## Motivation and Context

It can reduce package installation time when building.

