### PR TITLE
fix: title of user cell in team editer view

### DIFF
--- a/components/molecules/settings/cell/TeamMemberWideCell.vue
+++ b/components/molecules/settings/cell/TeamMemberWideCell.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
 .user-wide-cell-container {
   display: grid;
   grid-template-rows: 20px 20px;
-  grid-template-columns: 40px 16px auto 216px;
+  grid-template-columns: 40px 16px auto 168px;
   align-items: center;
   height: 56px;
   width: 100%;
@@ -154,19 +154,21 @@ export default Vue.extend({
 
   .title-item {
     grid-row: 1 / 2;
-    grid-column: 2 / 3;
+    grid-column: 3 / 4;
     font-size: 16px;
-    margin-left: 16px;
     font-weight: bold;
     color: $font-color;
+    overflow: scroll;
+    white-space: nowrap;
   }
 
   .detail-item {
     grid-row: 2 / 3;
-    grid-column: 2 / 3;
+    grid-column: 3 / 4;
     font-size: 12px;
-    margin-left: 16px;
     color: $font-color;
+    overflow: scroll;
+    white-space: nowrap;
   }
 
   .action-container {


### PR DESCRIPTION
## Related Issue

#254

## Checklist

- [x] Has your code worked appropriately?

## Description

- fixed grid position, and scroll div element when text is long.

## Screenshots (if appropriate):

<img width="948" alt="Screen Shot 2021-11-03 at 20 39 44" src="https://user-images.githubusercontent.com/34296711/140053858-f76bbe37-a7ed-483c-9006-21edddd5e0bc.png">

<img width="376" alt="Screen Shot 2021-11-03 at 20 41 32" src="https://user-images.githubusercontent.com/34296711/140053964-a6fbc119-1f1b-48e0-a3ab-f14633e600fd.png">


